### PR TITLE
Add the project's GitHub Sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: thekoalakoa

--- a/README.md
+++ b/README.md
@@ -441,6 +441,15 @@ built. Several changes in this project's history looked right, passed every fit
 gate, and were wrong on the device. The minor version moves when the known-issues
 list actually shrinks.
 
+## Sponsor
+
+If this is useful to you, you can sponsor the work at
+[github.com/sponsors/thekoalakoa](https://github.com/sponsors/thekoalakoa).
+
+It changes nothing about the core: it is GPLv3, the source is all here, and none of
+it is or will be behind a sponsorship. It also cannot buy you the ROM or the
+soundtrack — see [What this is not](#what-this-is-not).
+
 ## Lineage
 
 Built on six projects. GPLv3 throughout, so all of it stays credited.


### PR DESCRIPTION
`FUNDING.yml` was removed in ef018db because it was the upstream author's, inherited with the fork. This adds the maintainer's own, which turns the repo's Sponsor button back on pointing at the right person.

Verified the listing exists before wiring it up (`hasSponsorsListing: true` for `thekoalakoa`), so the button will not land on a dead page.

The README gets a short section, deliberately restrained: sponsorship changes nothing about the core, none of it is or will be gated behind sponsorship, and it cannot buy the ROM or the soundtrack.

The shipped core package is left alone. `info.txt` goes onto an SD card next to a game the player has to dump themselves, which is not the place for a funding solicitation — say the word if you'd rather it were there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
